### PR TITLE
Add mutation to buy an item

### DIFF
--- a/app/graphql/mutations/item_buy.rb
+++ b/app/graphql/mutations/item_buy.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Mutations
+  class ItemBuy < Mutations::BaseMutation
+    description 'Buy an item given its code.'
+
+    argument :code, Integer, 'The code for the item.', required: true
+
+    payload_type Types::ItemBuyResult
+
+    def resolve(code:)
+      case code
+      when 1 then { status: :insufficient_funds, available_cents: 20, price_cents: 100 }
+      when 2 then { status: :error, message: 'There is something wrong :(' }
+      else { status: :success, balance_cents: 20, items: [] }
+      end
+    end
+  end
+end

--- a/app/graphql/types/item_buy_insufficient_funds_error.rb
+++ b/app/graphql/types/item_buy_insufficient_funds_error.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Types
+  class ItemBuyInsufficientFundsError < Types::BaseObject
+    description 'An error that indicates the money deposited is less than the' \
+                ' price of the item selected.'
+
+    field :available_cents, Integer, 'The amount deposited.', null: false
+    field :price_cents, Integer, 'The amount required.', null: false
+  end
+end

--- a/app/graphql/types/item_buy_result.rb
+++ b/app/graphql/types/item_buy_result.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Types
+  class ItemBuyResult < Types::BaseUnion
+    description 'The result of the purchase. It can be either success or one of the errors.'
+
+    possible_types Types::ItemBuySuccess, Types::ItemBuyInsufficientFundsError, Types::SimpleError
+
+    def self.resolve_type(obj, _ctx)
+      case obj[:status]
+      when :insufficient_funds then Types::ItemBuyInsufficientFundsError
+      when :error then Types::SimpleError
+      when :success then Types::ItemBuySuccess
+      end
+    end
+  end
+end

--- a/app/graphql/types/item_buy_success.rb
+++ b/app/graphql/types/item_buy_success.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Types
+  class ItemBuySuccess < Types::BaseObject
+    description 'The purchase was successful, the item should be in the dispenser.'
+
+    field :balance_cents, Integer, 'The remaining amount.', null: false
+    field :items, [Types::Item], 'The updated list of items.', null: false
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -2,5 +2,6 @@
 
 module Types
   class MutationType < Types::BaseObject
+    field :item_buy, mutation: Mutations::ItemBuy
   end
 end

--- a/app/graphql/types/simple_error.rb
+++ b/app/graphql/types/simple_error.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Types
+  class SimpleError < Types::BaseObject
+    description 'A generic error with just a message.'
+
+    field :message, String, 'The error message', null: false
+  end
+end


### PR DESCRIPTION
This is a simplified hardcoded mutation, it has one successful result and two
failures - insufficienct funds or a generic error.

Clients must acknowledge the different result types otherwise they can't get any
data from the service.

Use code 1 for InsufficientFunds error, code 2 for generic error, or code 3 for
successful purchase.